### PR TITLE
fix OBJECT->move returning zero (MOVE_OK) when should be returning MOVE_DESTRUCTED

### DIFF
--- a/lib/std/Object.c
+++ b/lib/std/Object.c
@@ -64,7 +64,7 @@ int move(mixed dest) {
       environment(this_object())->add_encumbrance(-query_mass());
     set_last_location(environment(this_object()));
     move_object(ob);
-if(!this_object()) return 0;
+    if(!this_object()) return MOVE_DESTRUCTED;
     environment(this_object())->add_encumbrance(query_mass());
     return MOVE_OK;
 }


### PR DESCRIPTION
This was causing runtime errors on our nightmare3 mudlib running on fluffos v2017 when removing wandering monsters in a room reset.